### PR TITLE
Fix for TypeError: 'sage.rings.polynomial.polydict.ETupleIter' object…

### DIFF
--- a/simplicity.py
+++ b/simplicity.py
@@ -397,7 +397,7 @@ class Compiler(object):
       with scope('analyze'):
         permutations = sorted(all_permutations(range(n)),key=permutation_id)
         sequences = [None]*len(permutations)
-        unordered = zip([coef_to_id[c] for c in coefficients],[numpy.asarray(m.degrees()).reshape(n,d) for m in expansion.monomials()])
+        unordered = zip([coef_to_id[c] for c in coefficients],[numpy.asarray(list(m.degrees())).reshape(n,d) for m in expansion.monomials()])
         assert numpy.all(unordered[-1][1]==0)
         unordered = unordered[:-1]
         weights = numpy.int64(n)**numpy.arange(n*d).reshape(n,d)


### PR DESCRIPTION
… is not iterable

It seems that `m.degrees()` in `expansion.monomials()` was once a list, but now it is an iterator.  This fix solves the problem.

Nevertheless, SoS is still Greek to me :-)